### PR TITLE
fixed searching for city/village name

### DIFF
--- a/FoxSky.Img/FileProcessors/FileExtension.cs
+++ b/FoxSky.Img/FileProcessors/FileExtension.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FoxSky.Img.FileProcessors
+{
+    public enum FileExtension
+    {
+        JEPG,
+        JPG,
+        HEIC,
+        PNG,
+    }
+
+    public static class FileExtensionExtenstions
+    {
+        public static string ToExtension(this FileExtension fileExtension)
+        {
+            return fileExtension switch
+            {
+                FileExtension.JEPG => ".jpeg",
+                FileExtension.JPG => ".jpg",
+                FileExtension.HEIC => ".heic",
+                FileExtension.PNG => ".png",
+                _ => throw new ArgumentException("Unsupported file extension"),
+            };
+        }
+
+        public static IEnumerable<string> GetExtensions()
+        {
+            return Enum.GetValues(typeof(FileExtension))
+                .Cast<FileExtension>()
+                .Select(ext => ext.ToExtension());
+        }
+    }
+}

--- a/FoxSky.Img/FileProcessors/FileHandler.cs
+++ b/FoxSky.Img/FileProcessors/FileHandler.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.IO;
 using System.Linq;
 using System;
+using System.Text;
 
 namespace FoxSky.Img.Processors
 {
@@ -106,15 +107,20 @@ namespace FoxSky.Img.Processors
         private async Task<string> PrepareNewFileName(string srcFileName, string dstPath, DateTime? photoDate, ImageProcessor processor)
         {
             string location = string.Empty;
+            StringBuilder sb = new();
 
             if (processor.AddGeolocationFlag)
             {
                 location = TextUtils.RemoveSpaces(await geolocationService.ReverseGeolocationRequestTask(srcFileName, processor.UserEmail, processor.Radius));
             }
 
-            var fileName = processor.PicsOwnerSurname + "_" + (photoDate.HasValue ?
+            sb.Append(processor.PicsOwnerSurname);
+            sb.Append("_");
+            sb.Append(photoDate.HasValue ?
                 photoDate.Value.ToString("yyyy-MM-dd HH-mm-ss") + location :
                 Path.GetFileNameWithoutExtension(srcFileName));
+
+            string fileName = sb.ToString();
 
             var extension = Path.GetExtension(srcFileName).Trim();
 

--- a/FoxSky.Img/FileProcessors/FileHandler.cs
+++ b/FoxSky.Img/FileProcessors/FileHandler.cs
@@ -105,10 +105,15 @@ namespace FoxSky.Img.Processors
 
         private async Task<string> PrepareNewFileName(string srcFileName, string dstPath, DateTime? photoDate, ImageProcessor processor)
         {
-            var place = TextUtils.RemoveSpaces(await geolocationService.ReverseGeolocationRequestTask(srcFileName, processor.UserEmail, processor.Radius));
+            string location = string.Empty;
+
+            if (processor.AddGeolocationFlag)
+            {
+                location = TextUtils.RemoveSpaces(await geolocationService.ReverseGeolocationRequestTask(srcFileName, processor.UserEmail, processor.Radius));
+            }
 
             var fileName = processor.PicsOwnerSurname + "_" + (photoDate.HasValue ?
-                photoDate.Value.ToString("yyyy-MM-dd HH-mm-ss") + "_" + place :
+                photoDate.Value.ToString("yyyy-MM-dd HH-mm-ss") + location :
                 Path.GetFileNameWithoutExtension(srcFileName));
 
             var extension = Path.GetExtension(srcFileName).Trim();
@@ -120,7 +125,7 @@ namespace FoxSky.Img.Processors
             }
 
             var newFileName = Path.Combine(dstPath, fileName) + extension;
-            int i = 1;
+            int fileDuplicatesCounter = 1;
 
             while (File.Exists(newFileName))
             {
@@ -128,8 +133,8 @@ namespace FoxSky.Img.Processors
 
                 if (!differs) break;
 
-                newFileName = Path.Combine(dstPath, $"{fileName}_{i}") + extension;
-                i++;
+                newFileName = Path.Combine(dstPath, $"{fileName}_{fileDuplicatesCounter}") + extension;
+                fileDuplicatesCounter++;
             }
 
             return newFileName;

--- a/FoxSky.Img/FileProcessors/FileHandler.cs
+++ b/FoxSky.Img/FileProcessors/FileHandler.cs
@@ -20,12 +20,13 @@ namespace FoxSky.Img.Processors
             this.geolocationService = geolocationService;
         }
 
+        // TODO - remove this switch statement 
         public async Task<bool> ProcessImageFile(string srcFilePath, ImageProcessor processor)
         {
             try
             {
                 var photoDateTime = ExtractPhotoDateFromExif(srcFilePath);
-                var dstPath = PrepareDstDir(photoDateTime, processor.DstRootPath);
+                var dstPath = PrepareDstDir(photoDateTime, processor.DstRootPath!);
                 var dstFilePath = await PrepareNewFileName(srcFilePath, dstPath, photoDateTime, processor);
 
                 switch (processor.Mode)
@@ -37,9 +38,6 @@ namespace FoxSky.Img.Processors
                     case Mode.Copy:
                         File.Copy(srcFilePath, dstFilePath, true);
                         break;
-
-                    default:
-                        throw new ArgumentException($"Unsupported mode {processor.Mode}");
                 }
 
                 Logger.LogSuccess($"{srcFilePath} → {dstFilePath}");
@@ -109,9 +107,9 @@ namespace FoxSky.Img.Processors
             string location = string.Empty;
             StringBuilder sb = new();
 
-            if (processor.AddGeolocationFlag)
+            if (processor.GeolocationFlag)
             {
-                location = TextUtils.RemoveSpaces(await geolocationService.ReverseGeolocationRequestTask(srcFileName, processor.UserEmail, processor.Radius));
+                location = TextUtils.RemoveSpaces(await geolocationService.ReverseGeolocationRequestTask(srcFileName, processor.UserEmail!, processor.Radius!));
             }
 
             sb.Append(processor.PicsOwnerSurname);

--- a/FoxSky.Img/FileProcessors/ImageProcessor.cs
+++ b/FoxSky.Img/FileProcessors/ImageProcessor.cs
@@ -16,6 +16,7 @@ namespace FoxSky.Img.Processors
         public string? PicsOwnerSurname { get; set; }
         public string? SrcPath { get; set; }
         public string? DstRootPath { get; set; }
+        public bool AddGeolocationFlag { get; set; }
         public string? UserEmail { get; set; }
         public string? Radius { get; set; }
         public Mode Mode { get; set; }

--- a/FoxSky.Img/FileProcessors/ImageProcessor.cs
+++ b/FoxSky.Img/FileProcessors/ImageProcessor.cs
@@ -16,15 +16,16 @@ namespace FoxSky.Img.Processors
         public string? PicsOwnerSurname { get; set; }
         public string? SrcPath { get; set; }
         public string? DstRootPath { get; set; }
-        public bool AddGeolocationFlag { get; set; }
+        public bool GeolocationFlag { get; set; }
         public string? UserEmail { get; set; }
         public string? Radius { get; set; }
         public Mode Mode { get; set; }
 
-        public ImageProcessor(FileHandler fileHandler, GeolocationService geolocationService)
+        public ImageProcessor(FileHandler fileHandler, GeolocationService geolocationService, Mode mode)
         {
             this.fileHandler = fileHandler;
             this.geolocationService = geolocationService;
+            this.Mode = mode;
         }
 
         public async Task<bool> ProcessImages()

--- a/FoxSky.Img/FileProcessors/Mode.cs
+++ b/FoxSky.Img/FileProcessors/Mode.cs
@@ -8,7 +8,7 @@ namespace FoxSky.Img.FileProcessors
 {
     public enum Mode
     {
+        Copy,
         Move,
-        Copy
     }
 }

--- a/FoxSky.Img/FileProcessors/Mode.cs
+++ b/FoxSky.Img/FileProcessors/Mode.cs
@@ -8,7 +8,31 @@ namespace FoxSky.Img.FileProcessors
 {
     public enum Mode
     {
-        Copy,
-        Move,
+        Copy = 1,
+        Move = 2,
+    }
+
+    public static class ModeExtenstions
+    {
+        private static Dictionary<string, Mode> modesMap = new()
+        {
+            { "1", Mode.Copy },
+            { "2", Mode.Move }
+        };
+
+        public static Mode? GetModeString(string modeNumber)
+        {
+            Mode? mode = null;
+
+            foreach (var item in modesMap)
+            {
+                if (item.Value.ToString() == modeNumber)
+                {
+                    mode = item.Value;
+                }
+            }
+
+            return mode;
+        }
     }
 }

--- a/FoxSky.Img/FoxSky.Img.csproj
+++ b/FoxSky.Img/FoxSky.Img.csproj
@@ -9,10 +9,11 @@
 
   <ItemGroup>
     <PackageReference Include="Geocoding.Google" Version="4.0.1" />
-    <PackageReference Include="Google.Api.Gax" Version="4.8.0" />
-    <PackageReference Include="GoogleApi" Version="5.4.8" />
+    <PackageReference Include="Google.Api.Gax" Version="4.10.0" />
+    <PackageReference Include="GoogleApi" Version="5.8.4" />
+    <PackageReference Include="GeoCoordinate.NetStandard1" Version="1.0.1" />
     <PackageReference Include="MetadataExtractor" Version="2.8.1" />
-    <PackageReference Include="System.Device.Location.Portable" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
     <PackageReference Include="Wibci.CountryReverseGeocode" Version="2.1.0" />
   </ItemGroup>
 

--- a/FoxSky.Img/FoxSky.Img.sln
+++ b/FoxSky.Img/FoxSky.Img.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FoxSky.Img", "FoxSky.Img.csproj", "{D9E9394D-B68F-4AB7-96DE-993C0AB3A549}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D9E9394D-B68F-4AB7-96DE-993C0AB3A549}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9E9394D-B68F-4AB7-96DE-993C0AB3A549}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9E9394D-B68F-4AB7-96DE-993C0AB3A549}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9E9394D-B68F-4AB7-96DE-993C0AB3A549}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D15DEF7F-1006-49D9-9F6B-7F1C441C4BD2}
+	EndGlobalSection
+EndGlobal

--- a/FoxSky.Img/Program.cs
+++ b/FoxSky.Img/Program.cs
@@ -23,9 +23,9 @@ class Program
             return; 
         }
 
-        if (args.Length < 5)
+        if (args.Length < 3)
         {
-            Logger.LogError("Invalid params.");
+            Logger.LogError("Invalid base params.");
             Environment.ExitCode = 1;
             return;
         }
@@ -33,8 +33,18 @@ class Program
         imageProcessor.PicsOwnerSurname = args[0];
         imageProcessor.SrcPath = args[1];
         imageProcessor.DstRootPath = args[2];
-        imageProcessor.UserEmail = args[3];
-        imageProcessor.Radius = args[4];
+
+        imageProcessor.AddGeolocationFlag = args.Contains("-g");
+
+        if (imageProcessor.AddGeolocationFlag && args.Length < 5)
+        {
+            Logger.LogError("Invalid geolocation params.");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        imageProcessor.UserEmail = args.Length > 4 ? args[4] : null;
+        imageProcessor.Radius = args.Length > 5 ? args[5] : null;
 
         var resSuccess = Task.Run(async () => await imageProcessor.ProcessImages()).GetAwaiter().GetResult();
         Environment.ExitCode = resSuccess ? 0 : 1;

--- a/FoxSky.Img/Properties/launchSettings.json
+++ b/FoxSky.Img/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "FoxSky.Img": {
       "commandName": "Project",
-      "commandLineArgs": "Lis C:\\temp\\osmTest C:\\temp\\results -g marcel.test@gmail.com 500"
+      "commandLineArgs": "Lis C:\\temp\\osmTest C:\\temp\\results 1 -g marcel.test@gmail.com 500"
     }
   }
 }

--- a/FoxSky.Img/Properties/launchSettings.json
+++ b/FoxSky.Img/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "FoxSky.Img": {
       "commandName": "Project",
-      "commandLineArgs": "Lis C:\\temp\\osmTest C:\\temp\\results marcel.test@gmail.com 500"
+      "commandLineArgs": "Lis C:\\temp\\osmTest C:\\temp\\results -g marcel.test@gmail.com 500"
     }
   }
 }

--- a/FoxSky.Img/Service/GeolocationService.cs
+++ b/FoxSky.Img/Service/GeolocationService.cs
@@ -45,7 +45,7 @@ namespace FoxSky.Img.Service
                     $"format=json&email={userEmail}" +
                     $"&lat={location.Latitude.ToString(CultureInfo.InvariantCulture)}" +
                     $"&lon={location.Longitude.ToString(CultureInfo.InvariantCulture)}" +
-                    $"&zoom=10&addressdetails=1&accept-language=en");
+                    $"&zoom=13&addressdetails=1&accept-language=en");
 
                 string requestUri = sb.ToString();
 
@@ -75,9 +75,11 @@ namespace FoxSky.Img.Service
 
             if (address != null)
             {
-                var city = address["city"]?.ToString() ??
-                       address["town"]?.ToString() ??
-                       address["village"]?.ToString();
+                var city = address["village"]?.ToString() ??
+                           address["city"]?.ToString() ??
+                           address["town"]?.ToString() ??
+                           address["municipality"]?.ToString() ??
+                           address["county"]?.ToString();
 
                 sb.Append(city);
 

--- a/FoxSky.Img/Service/GeolocationService.cs
+++ b/FoxSky.Img/Service/GeolocationService.cs
@@ -1,13 +1,10 @@
 ﻿using FoxSky.Img.Utilities;
-using MetadataExtractor.Formats.Exif;
+using GoogleApi.Entities.Common;
 using MetadataExtractor;
+using MetadataExtractor.Formats.Exif;
 using Newtonsoft.Json.Linq;
 using System.Globalization;
 using System.Text;
-using GoogleApi.Entities.Common;
-using System.Device.Location;
-using System.Net.Http;
-using System.Threading.Tasks;
 
 namespace FoxSky.Img.Service
 {

--- a/FoxSky.Img/Service/GeolocationService.cs
+++ b/FoxSky.Img/Service/GeolocationService.cs
@@ -53,7 +53,12 @@ namespace FoxSky.Img.Service
 
                 if (response.IsSuccessStatusCode)
                 {
-                    fullLocationName = ExtractCityAndCountry(await response.Content.ReadAsStringAsync());
+                    sb.Clear();
+
+                    sb.Append('_');
+                    sb.Append(ExtractCityAndCountry(await response.Content.ReadAsStringAsync()));
+
+                    fullLocationName = sb.ToString();
 
                     locationCache.AddLocationToCache(location, fullLocationName);
                 }

--- a/FoxSky.Img/Service/LocationCache.cs
+++ b/FoxSky.Img/Service/LocationCache.cs
@@ -1,7 +1,5 @@
-﻿using GoogleApi.Entities.Common;
-using System.Collections.Generic;
-using System.Device.Location;
-using System.Linq;
+﻿using GeoCoordinatePortable;
+using GoogleApi.Entities.Common;
 
 namespace FoxSky.Img.Service
 {
@@ -26,6 +24,7 @@ namespace FoxSky.Img.Service
         {
             var coord1 = new GeoCoordinate(loc1.Latitude, loc1.Longitude);
             var coord2 = new GeoCoordinate(loc2.Latitude, loc2.Longitude);
+
             return coord1.GetDistanceTo(coord2) <= distanceInMeters;
         }
     }


### PR DESCRIPTION
Reworked geolocation service and file extension handling. 

1. From now to run program with geolocation you have to provide "-g" flag in launchSettings.json followed by user email OSM API and searching radius.

2. Added enum and class for better file extensions handling. Now you can define desired file extensions in enum and add mapping to its string representation.